### PR TITLE
Draft WIP: Provide replication feature from Teragrep Mariadb to HBase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
   </scm>
   <properties>
     <changelist>-SNAPSHOT</changelist>
+    <hbase.verion>2.6.1</hbase.verion>
     <java.version>11</java.version>
     <junit.version>5.10.2</junit.version>
     <maven.compiler.source>11</maven.compiler.source>
@@ -47,7 +48,7 @@
     <dependency>
       <groupId>org.apache.hbase</groupId>
       <artifactId>hbase-client</artifactId>
-      <version>2.6.1</version>
+      <version>${hbase.verion}</version>
     </dependency>
     <!-- Logging -->
     <dependency>
@@ -78,6 +79,19 @@
       <groupId>nl.jqno.equalsverifier</groupId>
       <artifactId>equalsverifier</artifactId>
       <version>3.17.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-testing-util</artifactId>
+      <version>${hbase.verion}</version>
+      <scope>test</scope>
+    </dependency>
+    <!-- hbase-testing-util supports only JUnit 4 -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/com/teragrep/hbs_03/HBaseClient.java
+++ b/src/main/java/com/teragrep/hbs_03/HBaseClient.java
@@ -1,0 +1,58 @@
+/*
+ * Teragrep Metadata Using HBase (hbs_03)
+ * Copyright (C) 2024 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.hbs_03;
+
+import org.apache.hadoop.conf.Configuration;
+
+public class HBaseClient {
+
+    private final Configuration configuration;
+
+    public HBaseClient(Configuration configuration) {
+        this.configuration = configuration;
+    }
+
+}

--- a/src/main/java/com/teragrep/hbs_03/HBaseRow.java
+++ b/src/main/java/com/teragrep/hbs_03/HBaseRow.java
@@ -1,0 +1,104 @@
+/*
+ * Teragrep Metadata Using HBase (hbs_03)
+ * Copyright (C) 2024 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.hbs_03;
+
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.List;
+
+public final class HBaseRow implements Row {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(HBaseRow.class);
+
+    private final List<Object> values;
+    private final List<String> columns;
+    private final RowKey rowKey;
+
+    public HBaseRow(List<Object> values) {
+        this(
+                values,
+                Arrays
+                        .asList(
+                                "epoch", "exp", "pth", "orig_nm", "archived", "checksum", "etag", "logtag",
+                                "uncmp_size", "meta", "src_nm", "ctg_nm", "bckt_nm", "host_nm", "strm_dir", "strm_tag",
+                                "log_grp_nm"
+                        ),
+                new RowKey(values.get(14).toString(), values.get(0).toString())
+        );
+    }
+
+    private HBaseRow(List<Object> values, List<String> columns, RowKey rowKey) {
+        this.values = values;
+        this.columns = columns;
+        this.rowKey = rowKey;
+    }
+
+    public Put put() {
+        if (values.size() != columns.size()) {
+            throw new IllegalStateException("Number of values does not match the number of columns");
+        }
+        // create put with a row key
+        final Put put = new Put(rowKey.bytes());
+        int i = 0;
+        final byte[] metaCFBytes = Bytes.toBytes("meta");
+        // iterate values and put to corresponding columns
+        for (final Object value : values) {
+            final String column = columns.get(i);
+            put.addColumn(metaCFBytes, Bytes.toBytes(column), Bytes.toBytes((value.toString())));
+            LOGGER.trace("Col: <{}>=<{}> ", column, value);
+            i++;
+        }
+        return put;
+    }
+
+    public String id() {
+        return rowKey.value();
+    }
+}

--- a/src/main/java/com/teragrep/hbs_03/LogfileTable.java
+++ b/src/main/java/com/teragrep/hbs_03/LogfileTable.java
@@ -1,0 +1,151 @@
+/*
+ * Teragrep Metadata Using HBase (hbs_03)
+ * Copyright (C) 2024 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.hbs_03;
+
+import org.apache.hadoop.hbase.MasterNotRunningException;
+import org.apache.hadoop.hbase.TableExistsException;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.client.BufferedMutator;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.ColumnFamilyDescriptor;
+import org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.ResultScanner;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.client.Table;
+import org.apache.hadoop.hbase.client.TableDescriptor;
+import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public final class LogfileTable {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(LogfileTable.class);
+    private final Connection connection;
+    private final TableName tableName;
+
+    public LogfileTable(final Connection connection) {
+        this(connection, TableName.valueOf("logfile"));
+    }
+
+    public LogfileTable(final Connection connection, TableName tableName) {
+        this.connection = connection;
+        this.tableName = tableName;
+    }
+
+    public void create() {
+        try (final Admin admin = connection.getAdmin()) {
+
+            final TableDescriptor descriptor = TableDescriptorBuilder
+                    .newBuilder(tableName)
+                    .setColumnFamilies(columnFamilyDescriptors())
+                    .build();
+            admin.createTable(descriptor);
+
+            LOGGER.info("Created Logfile table to HBase");
+
+        }
+        catch (final MasterNotRunningException e) {
+            throw new RuntimeException("Master was not running: " + e.getMessage());
+        }
+        catch (final TableExistsException e) {
+            throw new RuntimeException("Logfile table already exists: " + e.getMessage());
+        }
+        catch (final IllegalArgumentException e) {
+            throw new RuntimeException(tableName + " restricted: " + e.getMessage());
+        }
+        catch (final IOException e) {
+            throw new RuntimeException("Error creating logfile table: " + e.getMessage());
+        }
+    }
+
+    public ResultScanner scan(final Scan scan) {
+        try (final Table table = connection.getTable(tableName)) {
+            final ResultScanner result = table.getScanner(scan);
+            return result;
+        }
+        catch (IOException e) {
+            throw new RuntimeException("Error writing files to table: " + e.getMessage());
+        }
+    }
+
+    public void put(final Put put) {
+        try (final Table table = connection.getTable(tableName)) {
+            table.put(put);
+            if (LOGGER.isInfoEnabled()) {
+                LOGGER.info("Put <{}> into database", put);
+            }
+        }
+        catch (final IOException e) {
+            throw new RuntimeException("Error writing files to table: " + e.getMessage());
+        }
+    }
+
+    public void putAll(final List<Put> puts) {
+        try (final BufferedMutator mutator = connection.getBufferedMutator(tableName)) {
+            if (LOGGER.isInfoEnabled()) {
+                LOGGER.info("Putting <{}> objects", puts.size());
+            }
+            mutator.mutate(puts);
+            mutator.flush();
+        }
+        catch (final IOException e) {
+            throw new RuntimeException("Error writing files to table: " + e.getMessage());
+        }
+    }
+
+    private List<ColumnFamilyDescriptor> columnFamilyDescriptors() {
+        return Collections
+                .unmodifiableList(Arrays.asList(ColumnFamilyDescriptorBuilder.newBuilder(Bytes.toBytes("meta")).build(), ColumnFamilyDescriptorBuilder.newBuilder(Bytes.toBytes("bloom")).build()));
+    }
+}

--- a/src/main/java/com/teragrep/hbs_03/Replication.java
+++ b/src/main/java/com/teragrep/hbs_03/Replication.java
@@ -1,0 +1,54 @@
+/*
+ * Teragrep Metadata Using HBase (hbs_03)
+ * Copyright (C) 2024 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.hbs_03;
+
+/** Entry point class to start replication */
+public class Replication {
+
+    public static void main(String[] args) {
+        // TODO apply args and start replication process
+    }
+}

--- a/src/main/java/com/teragrep/hbs_03/Row.java
+++ b/src/main/java/com/teragrep/hbs_03/Row.java
@@ -1,0 +1,57 @@
+/*
+ * Teragrep Metadata Using HBase (hbs_03)
+ * Copyright (C) 2024 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.hbs_03;
+
+import org.apache.hadoop.hbase.client.Put;
+
+public interface Row {
+
+    /** Row values as a Put object that can be inserted into the logfile table */
+    public abstract Put put();
+
+    /** unique identifier for the row (row key, SQL id) */
+    public abstract String id();
+}

--- a/src/main/java/com/teragrep/hbs_03/RowKey.java
+++ b/src/main/java/com/teragrep/hbs_03/RowKey.java
@@ -1,0 +1,74 @@
+/*
+ * Teragrep Metadata Using HBase (hbs_03)
+ * Copyright (C) 2024 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.hbs_03;
+
+import org.apache.hadoop.hbase.util.Bytes;
+
+/** Represents a row key for HBase row */
+public final class RowKey {
+
+    private final String source;
+    private final String epoch;
+
+    public RowKey(final String source, final String epoch) {
+        this.source = source;
+        this.epoch = epoch;
+    }
+
+    public String value() {
+        if (source.isEmpty() || epoch.isEmpty()) {
+            throw new IllegalArgumentException("Given row key values were empty");
+        }
+        final long epochLong = Long.parseLong(epoch);
+        final long negativeEpoch = -epochLong;
+        // formats source string to be equal length non-negative integers
+        return String.format("%08x", source.hashCode()) + "#" + negativeEpoch;
+    }
+
+    public byte[] bytes() {
+        return Bytes.toBytes(value());
+    }
+}

--- a/src/main/java/com/teragrep/hbs_03/SQLDatabaseClient.java
+++ b/src/main/java/com/teragrep/hbs_03/SQLDatabaseClient.java
@@ -1,0 +1,73 @@
+/*
+ * Teragrep Metadata Using HBase (hbs_03)
+ * Copyright (C) 2024 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.hbs_03;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class SQLDatabaseClient {
+
+    private final String username;
+    private final String password;
+    private final String url;
+
+    public SQLDatabaseClient(String username, String password, String url) {
+        this.username = username;
+        this.password = password;
+        this.url = url;
+    }
+
+    public ResultSet query(final String sql) {
+        try (final Connection connection = DriverManager.getConnection(url, username, password)) {
+            return connection.prepareStatement(sql).executeQuery();
+        }
+        catch (final SQLException e) {
+            throw new RuntimeException("Error executing query: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/teragrep/hbs_03/SQLQuery.java
+++ b/src/main/java/com/teragrep/hbs_03/SQLQuery.java
@@ -1,0 +1,201 @@
+/*
+ * Teragrep Metadata Using HBase (hbs_03)
+ * Copyright (C) 2024 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.hbs_03;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class SQLQuery {
+
+    private final ValidName tableName;
+    private final long limit;
+    private final Connection connection;
+
+    public SQLQuery(Connection connection) {
+        this(connection, new ValidName("streamdb"), 0);
+    }
+
+    public SQLQuery(Connection connection, long limit) {
+        this(connection, new ValidName("streamdb"), limit);
+    }
+
+    public SQLQuery(Connection connection, String tableName) {
+        this(connection, new ValidName(tableName), 0);
+    }
+
+    public SQLQuery(Connection connection, String tableName, long limit) {
+        this(connection, new ValidName(tableName), limit);
+    }
+
+    public SQLQuery(Connection connection, ValidName tableName, long limit) {
+        this.tableName = tableName;
+        this.limit = limit;
+        this.connection = connection;
+    }
+
+    public List<Row> rows() {
+        final List<Row> rows = new ArrayList<>();
+        try (ResultSet resultSet = result()) {
+            while (resultSet.next()) {
+                final String id = resultSet.getString(1);
+                final String epoch = resultSet.getString(2);
+                final String exp = resultSet.getString(3);
+                final String pth = resultSet.getString(4);
+                final String orig_nn = resultSet.getString(5);
+                final String archived = resultSet.getString(6);
+                final String checksum = resultSet.getString(7);
+                final String etag = resultSet.getString(8);
+                final String logtag = resultSet.getString(9);
+                final String uncmp_size = resultSet.getString(10);
+                final String meta = resultSet.getString(11);
+                final String src_nm = resultSet.getString(12);
+                final String ctg_nm = resultSet.getString(13);
+                final String bckt_nm = resultSet.getString(14);
+                final String host_nm = resultSet.getString(15);
+                final String strm_dir = resultSet.getString(16);
+                final String strm_tag = resultSet.getString(17);
+                final String log_grp_nm = resultSet.getString(18);
+                final List<Object> values = Arrays
+                        .asList(
+                                id, epoch, exp, pth, orig_nn, archived, checksum, etag, logtag, uncmp_size, meta,
+                                src_nm, ctg_nm, bckt_nm, host_nm, strm_dir, strm_tag, log_grp_nm
+                        );
+                final Row row = new SQLRow(values);
+                rows.add(row);
+            }
+        }
+        catch (final SQLException e) {
+            throw new RuntimeException("Error getting rows :" + e.getMessage());
+        }
+        return rows;
+    }
+
+    private ResultSet result() {
+        try (final PreparedStatement stmt = connection.prepareStatement(sql())) {
+            return stmt.executeQuery();
+        }
+        catch (final SQLException e) {
+            throw new RuntimeException("Error executing query: " + e.getMessage());
+        }
+    }
+
+    private String sql() {
+        final String sql;
+        if (limit > 0) {
+            sql = MessageFormat
+                    .format(
+                            "SELECT " + "`logfile`.`id` AS `id`, UNIX_TIMESTAMP(`logfile`.`logdate`) AS `epoch`,"
+                                    + "    `logfile`.`expiration` AS `exp`," + "    `logfile`.`path` AS `pth`,"
+                                    + "    `logfile`.`original_filename` AS `orig_nm`,"
+                                    + "    UNIX_TIMESTAMP(`logfile`.`archived`) AS `archived`,"
+                                    + "    `logfile`.`sha256_checksum` AS `checksum`,"
+                                    + "    `logfile`.`archive_etag` AS `etag`," + "    `logfile`.`logtag` AS `logtag`,"
+                                    + "    `logfile`.`uncompressed_file_size` AS `uncomp_sz`,"
+                                    + "    JSON_OBJECTAGG(`metadata_value`.`value_key`, `metadata_value`.`value`) AS `meta`,"
+                                    + "    `source_system`.`name` AS `source_nm`,"
+                                    + "    `category`.`name` AS `ctg_nm`," + "    `bucket`.`name` AS `bckt_nm`,"
+                                    + "    `host`.`name` AS `host_nm`,"
+                                    + "    `{0}`.`stream`.`directory` AS `strm_dir`,"
+                                    + "    `{0}`.`stream`.`tag` AS `strm_tag`,"
+                                    + "    `{0}`.`log_group`.`name` AS `log_grp_nm`" + "FROM " + "    `logfile`"
+                                    + "LEFT JOIN "
+                                    + "    `metadata_value` ON `logfile`.`id` = `metadata_value`.`logfile_id`"
+                                    + "LEFT JOIN "
+                                    + "    `source_system` ON `logfile`.`source_system_id` = `source_system`.`id`"
+                                    + "LEFT JOIN " + "    `category` ON `logfile`.`category_id` = `category`.`id`"
+                                    + "LEFT JOIN " + "    `bucket` ON `logfile`.`bucket_id` = `bucket`.`id`"
+                                    + "LEFT JOIN " + "    `host` ON `logfile`.`host_id` = `host`.`id`" + "LEFT JOIN "
+                                    + "    `{0}`.`host` AS `stream_host` ON `host`.`name` = `stream_host`.`name`"
+                                    + "LEFT JOIN "
+                                    + "    `{0}`.`log_group` AS `log_group` ON `stream_host`.`gid` = `log_group`.`id`"
+                                    + "LEFT JOIN "
+                                    + "    `{0}`.`stream` AS `stream` ON `log_group`.`id` = `stream`.`gid`"
+                                    + "GROUP BY " + "    `logfile`.`id`" + "LIMIT {1};",
+                            tableName.name(), limit
+                    );
+        }
+        else {
+            sql = MessageFormat
+                    .format(
+                            "SELECT " + "`logfile`.`id` AS `id`, UNIX_TIMESTAMP(`logfile`.`logdate`) AS `epoch`,"
+                                    + "    `logfile`.`expiration` AS `exp`," + "    `logfile`.`path` AS `pth`,"
+                                    + "    `logfile`.`original_filename` AS `orig_nm`,"
+                                    + "    UNIX_TIMESTAMP(`logfile`.`archived`) AS `archived`,"
+                                    + "    `logfile`.`sha256_checksum` AS `checksum`,"
+                                    + "    `logfile`.`archive_etag` AS `etag`," + "    `logfile`.`logtag` AS `logtag`,"
+                                    + "    `logfile`.`uncompressed_file_size` AS `uncomp_sz`,"
+                                    + "    JSON_OBJECTAGG(`metadata_value`.`value_key`, `metadata_value`.`value`) AS `meta`,"
+                                    + "    `source_system`.`name` AS `source_nm`,"
+                                    + "    `category`.`name` AS `ctg_nm`," + "    `bucket`.`name` AS `bckt_nm`,"
+                                    + "    `host`.`name` AS `host_nm`,"
+                                    + "    `{0}`.`stream`.`directory` AS `strm_dir`,"
+                                    + "    `{0}`.`stream`.`tag` AS `strm_tag`,"
+                                    + "    `{0}`.`log_group`.`name` AS `log_grp_nm`" + "FROM " + "    `logfile`"
+                                    + "LEFT JOIN "
+                                    + "    `metadata_value` ON `logfile`.`id` = `metadata_value`.`logfile_id`"
+                                    + "LEFT JOIN "
+                                    + "    `source_system` ON `logfile`.`source_system_id` = `source_system`.`id`"
+                                    + "LEFT JOIN " + "    `category` ON `logfile`.`category_id` = `category`.`id`"
+                                    + "LEFT JOIN" + "    `bucket` ON `logfile`.`bucket_id` = `bucket`.`id`"
+                                    + "LEFT JOIN" + "    `host` ON `logfile`.`host_id` = `host`.`id`" + "LEFT JOIN"
+                                    + "    `{0}`.`host` AS `stream_host` ON `host`.`name` = `stream_host`.`name`"
+                                    + "LEFT JOIN"
+                                    + "    `{0}`.`log_group` AS `log_group` ON `stream_host`.`gid` = `log_group`.`id`"
+                                    + "LEFT JOIN"
+                                    + "    `{0}`.`stream` AS `stream` ON `log_group`.`id` = `stream`.`gid`" + "GROUP BY"
+                                    + "    `logfile`.`id`;",
+                            tableName.name()
+                    );
+        }
+        return sql;
+    }
+}

--- a/src/main/java/com/teragrep/hbs_03/SQLRow.java
+++ b/src/main/java/com/teragrep/hbs_03/SQLRow.java
@@ -1,0 +1,83 @@
+/*
+ * Teragrep Metadata Using HBase (hbs_03)
+ * Copyright (C) 2024 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.hbs_03;
+
+import org.apache.hadoop.hbase.client.Put;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public final class SQLRow implements Row {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SQLRow.class);
+
+    private final List<Object> values;
+    private final String id;
+
+    public SQLRow(final List<Object> values) {
+        this(values, values.get(0).toString());
+    }
+
+    public SQLRow(final List<Object> values, String id) {
+        this.values = values;
+        this.id = id;
+    }
+
+    @Override
+    public Put put() {
+        final List<Object> withoutIDList = new ArrayList<>(values.subList(1, values.size()));
+        final Put put = new HBaseRow(withoutIDList).put();
+        LOGGER.info("SQLRow id=<{}> as <{}", id, put);
+        return put;
+    }
+
+    @Override
+    public String id() {
+        return id;
+    }
+}

--- a/src/main/java/com/teragrep/hbs_03/ValidName.java
+++ b/src/main/java/com/teragrep/hbs_03/ValidName.java
@@ -1,0 +1,77 @@
+/*
+ * Teragrep Metadata Using HBase (hbs_03)
+ * Copyright (C) 2024 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.hbs_03;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class ValidName {
+
+    private final String name;
+    private final Pattern pattern;
+
+    public ValidName(final String name) {
+        this(name, Pattern.compile("^[a-zA-Z_]+$"));
+    }
+
+    public ValidName(final String name, final Pattern pattern) {
+        this.name = name;
+        this.pattern = pattern;
+    }
+
+    public String name() {
+        if (name.length() > 64) {
+            throw new RuntimeException("Name was longer than maximum length 64");
+        }
+        final Matcher matcher = pattern.matcher(name);
+        if (matcher.matches()) {
+            return name;
+        }
+        else {
+            throw new RuntimeException("Illegal format for name <" + name + ">. Use only alphabets or symbol _");
+        }
+    }
+}

--- a/src/test/java/com/teragrep/hbs_03/HBaseRowTest.java
+++ b/src/test/java/com/teragrep/hbs_03/HBaseRowTest.java
@@ -1,0 +1,83 @@
+/*
+ * Teragrep Metadata Using HBase (hbs_03)
+ * Copyright (C) 2024 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.hbs_03;
+
+import org.apache.hadoop.hbase.client.Put;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class HBaseRowTest {
+
+    @Test
+    public void testRowKey() {
+        final List<Object> values = Arrays
+                .asList(
+                        "12546854124", "exp", "pth", "orig_nm", "archived", "checksum", "etag", "logtag", "uncmp_size",
+                        "meta", "src_nm", "ctg_nm", "bckt_nm", "host_nm", "strm_dir", "strm_tag", "log_grp_nm"
+                );
+        final HBaseRow row = new HBaseRow(values);
+        // hash of strm_dir and negative epoch
+        final String expected = "6b2f2e2a#-12546854124";
+        final String rowkey = row.id();
+        Assertions.assertEquals(expected, rowkey);
+    }
+
+    @Test
+    public void testPut() {
+        final List<Object> values = Arrays
+                .asList(
+                        "12546854124", "exp", "pth", "orig_nm", "archived", "checksum", "etag", "logtag", "uncmp_size",
+                        "meta", "src_nm", "ctg_nm", "bckt_nm", "host_nm", "strm_dir", "strm_tag", "log_grp_nm"
+                );
+        final HBaseRow row = new HBaseRow(values);
+        Put put = row.put();
+        Assertions.assertEquals(17, put.size());
+
+    }
+}

--- a/src/test/java/com/teragrep/hbs_03/LogfileTableTest.java
+++ b/src/test/java/com/teragrep/hbs_03/LogfileTableTest.java
@@ -1,0 +1,140 @@
+/*
+ * Teragrep Metadata Using HBase (hbs_03)
+ * Copyright (C) 2024 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.hbs_03;
+
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.client.ConnectionFactory;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.ResultScanner;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.testing.TestingHBaseCluster;
+import org.apache.hadoop.hbase.testing.TestingHBaseClusterOption;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class LogfileTableTest {
+
+    private final String username = "streamdb";
+    private final String password = "streamdb_pass";
+    private final String url = "jdbc:mariadb://192.168.49.2:31420/archiver_journal_tyrael";
+
+    private TestingHBaseCluster hbase;
+    private Admin admin;
+    private org.apache.hadoop.hbase.client.Connection hbaseConn;
+
+    @BeforeAll
+    public void setup() {
+        Assertions.assertDoesNotThrow(() -> {
+            hbase = TestingHBaseCluster.create(TestingHBaseClusterOption.builder().build());
+            hbase.start();
+            hbaseConn = ConnectionFactory.createConnection(hbase.getConf());
+            admin = hbaseConn.getAdmin();
+        });
+    }
+
+    @AfterAll
+    public void tearDown() {
+        Assertions.assertDoesNotThrow(() -> {
+            admin.close();
+            hbaseConn.close();
+            hbase.stop();
+        });
+    }
+
+    @Test
+    @Disabled("Cluster setup not working")
+    public void testCreate() {
+        Assertions.assertDoesNotThrow(() -> new LogfileTable(hbaseConn).create());
+        Assertions.assertDoesNotThrow(() -> {
+            final boolean exists = admin.tableExists(TableName.valueOf("logfile"));
+            Assertions.assertTrue(exists);
+        });
+    }
+
+    @Test
+    @Disabled("Cluster setup not working")
+    @EnabledIfSystemProperty(
+            named = "database.tests.enabled",
+            matches = "true"
+    )
+    public void testPut() {
+        final LogfileTable table = Assertions.assertDoesNotThrow(() -> new LogfileTable(hbaseConn));
+        Assertions.assertDoesNotThrow(table::create);
+
+        final List<Put> putList = Assertions.assertDoesNotThrow(() -> {
+            final Connection conn = DriverManager.getConnection(url, username, password);
+            final SQLQuery query = new SQLQuery(conn, "archiver_streamdb_tyrael", 10);
+            return query.rows().stream().map(Row::put).collect(Collectors.toList());
+        });
+
+        Assertions.assertEquals(10, putList.size());
+        table.putAll(putList);
+        Scan scan = new Scan();
+        scan.addFamily(Bytes.toBytes("meta"));
+        ResultScanner scanner = table.scan(scan);
+        int loops = 0;
+        for (Result result : scanner) {
+            System.out.println("HBase row result: " + result);
+            loops++;
+        }
+        scanner.close();
+        Assertions.assertEquals(10, loops);
+    }
+}

--- a/src/test/java/com/teragrep/hbs_03/RowKeyTest.java
+++ b/src/test/java/com/teragrep/hbs_03/RowKeyTest.java
@@ -1,0 +1,71 @@
+/*
+ * Teragrep Metadata Using HBase (hbs_03)
+ * Copyright (C) 2024 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.hbs_03;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class RowKeyTest {
+
+    @Test
+    public void testRowKey() {
+        final String src = "source";
+        final String epoch = "946684800";
+        final RowKey rowKey = new RowKey(src, epoch);
+        final String expected = "ca90681b#-946684800";
+        Assertions.assertEquals(expected, rowKey.value());
+    }
+
+    @Test
+    public void testEqualLength() {
+        final String src1 = "source";
+        final String src2 = "source_name";
+        final String epoch = "946684800";
+        final byte[] rowKey1 = new RowKey(src1, epoch).bytes();
+        final byte[] rowKey2 = new RowKey(src2, epoch).bytes();
+        Assertions.assertEquals(rowKey1.length, rowKey2.length);
+    }
+}

--- a/src/test/java/com/teragrep/hbs_03/SQLDatabaseClientTest.java
+++ b/src/test/java/com/teragrep/hbs_03/SQLDatabaseClientTest.java
@@ -1,0 +1,79 @@
+/*
+ * Teragrep Metadata Using HBase (hbs_03)
+ * Copyright (C) 2024 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.hbs_03;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import java.sql.ResultSet;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class SQLDatabaseClientTest {
+
+    private final String username = System.getProperty("test.db.username");
+    private final String password = System.getProperty("test.db.password");
+    private final String url = System.getProperty("test.db.url");
+
+    @Test
+    @EnabledIfSystemProperty(
+            named = "runDatabaseTests",
+            matches = "true"
+    )
+    public void testQuery() {
+        SQLDatabaseClient client = new SQLDatabaseClient(username, password, url);
+        String sql = "SELECT `id` FROM logfile LIMIT 10";
+        ResultSet rs = Assertions.assertDoesNotThrow(() -> client.query(sql));
+        Assertions.assertDoesNotThrow(() -> {
+            int loops = 0;
+            while (rs.next()) {
+                loops++;
+            }
+            Assertions.assertEquals(10, loops);
+        });
+    }
+}

--- a/src/test/java/com/teragrep/hbs_03/SQLQueryTest.java
+++ b/src/test/java/com/teragrep/hbs_03/SQLQueryTest.java
@@ -1,0 +1,75 @@
+/*
+ * Teragrep Metadata Using HBase (hbs_03)
+ * Copyright (C) 2024 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.hbs_03;
+
+import org.apache.hadoop.hbase.client.Put;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SQLQueryTest {
+
+    private final String username = System.getProperty("test.db.username");
+    private final String password = System.getProperty("test.db.password");
+    private final String url = System.getProperty("test.db.url");
+    private final Connection conn = Assertions
+            .assertDoesNotThrow(() -> DriverManager.getConnection(url, username, password));
+
+    @Test
+    public void testQuery() {
+        SQLQuery query = new SQLQuery(conn, "archiver_streamdb_tyrael", 10);
+        List<Row> rows = query.rows();
+        Assertions.assertEquals(10, rows.size());
+        Put put = rows.get(0).put();
+        String expected = "{\"totalColumns\":17,\"row\":\"000181a8#-1603065600\",\"families\":{\"meta\":[{\"qualifier\":\"epoch\",\"vlen\":10,\"tag\":[],\"timestamp\":\"9223372036854775807\"},{\"qualifier\":\"exp\",\"vlen\":10,\"tag\":[],\"timestamp\":\"9223372036854775807\"},{\"qualifier\":\"pth\",\"vlen\":60,\"tag\":[],\"timestamp\":\"9223372036854775807\"},{\"qualifier\":\"orig_nm\",\"vlen\":21,\"tag\":[],\"timestamp\":\"9223372036854775807\"}]},\"ts\":\"9223372036854775807\"}";
+        Assertions.assertEquals(expected, put.toString());
+    }
+}

--- a/src/test/java/com/teragrep/hbs_03/SQLRowTest.java
+++ b/src/test/java/com/teragrep/hbs_03/SQLRowTest.java
@@ -1,0 +1,83 @@
+/*
+ * Teragrep Metadata Using HBase (hbs_03)
+ * Copyright (C) 2024 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.hbs_03;
+
+import org.apache.hadoop.hbase.client.Put;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class SQLRowTest {
+
+    @Test
+    public void testRowKey() {
+        final List<Object> values = Arrays
+                .asList(
+                        "1", "12546854124", "exp", "pth", "orig_nm", "archived", "checksum", "etag", "logtag",
+                        "uncmp_size", "meta", "src_nm", "ctg_nm", "bckt_nm", "host_nm", "strm_dir", "strm_tag",
+                        "log_grp_nm"
+                );
+        final SQLRow row = new SQLRow(values);
+        final String expected = "1";
+        final String rowkey = row.id();
+        Assertions.assertEquals(expected, rowkey);
+    }
+
+    @Test
+    public void testPut() {
+        final List<Object> values = Arrays
+                .asList(
+                        "1", "12546854124", "exp", "pth", "orig_nm", "archived", "checksum", "etag", "logtag",
+                        "uncmp_size", "meta", "src_nm", "ctg_nm", "bckt_nm", "host_nm", "strm_dir", "strm_tag",
+                        "log_grp_nm"
+                );
+        final SQLRow row = new SQLRow(values);
+        Put put = row.put();
+        Assertions.assertEquals(17, put.size());
+    }
+}


### PR DESCRIPTION
This is a draft PR to easily review changes.

## Features 
- [x] Query needed data from SQL 
- [x] Create HBase schemas tables and column families to HBase
- [x] Convert SQL data to HBase compatible form 
- [ ] Fully unit tested
- [ ] Write queried SQL data to HBase
- [ ] Configure HBase connection
- [ ] Configure MariaDB connection
- [ ] Make jar configurable and runnable from command line 
- [ ] Run replication process as a systemd service